### PR TITLE
Fix mdbook deploy failures

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -25,8 +25,9 @@ jobs:
           # curl -sSL $url -o mdbook.tar.gz
           # tar xzf mdbook.tar.gz --directory=./mdbook
           # echo `pwd`/mdbook >> $GITHUB_PATH
-          cargo install mdbook mdbook-mermaid mdbook-alerts mdbook-emojicodes mdbook-toc mdbook-pikchr
+          cargo install mdbook mdbook-mermaid mdbook-alerts mdbook-emojicodes mdbook-toc mdbook-pikchr mdbook-mermaid-animate
           mdbook-mermaid install doc
+          mdbook-mermaid-animate install doc
       - name: Build Book
         run: |
           cd doc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to this project will be documented in this file.
 - Added recursive Makefile example and comparison
 - Reorganized SUMMARY.md with improved structure
 - Added examples for project_C and project_expand
+- Fixed expand.md to reference correct demo project path
 
 ## [0.1.5]
 

--- a/doc/src/expand.md
+++ b/doc/src/expand.md
@@ -7,13 +7,13 @@ first we have a description of messages in different languages, in a yaml file.
 we have a code generator, written in rust. The code source is part of the project
 
 This will generate C files, and we have our `main.c` that will print some messages
-file `greetings.yml`
+file `languages.yml`
 
 ```yml
-{{#include ../../demo_projects/demo_expand/greetings.yml}}
+{{#include ../../demo_projects/project_expand/languages.yml}}
 ```
 
-from the `greetings.yaml` file C files and H files will be generated, but for now we don't have this list so we cannot build the build graph,
+from the `languages.yml` file C files and H files will be generated, but for now we don't have this list so we cannot build the build graph,
 so our graph looks like this but is incomplete
 
 


### PR DESCRIPTION
## Summary
- Fix expand.md to reference `project_expand/languages.yml` instead of deleted `demo_expand/greetings.yml`
- Add `mdbook-mermaid-animate` to CI workflow

## Test plan
- [x] mdbook build should now succeed in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)