### PR TITLE
Bump version to 0.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.1.8] - 2026-01-29
+
 ### Added
 - **Colored status logs**: Build status now displayed with colors for better visibility
   - `MF` (MountedFailed): red

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1895,7 +1895,7 @@ checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 
 [[package]]
 name = "yamake"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "argh",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yamake"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2024"
 description="yet another make tool."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary
- Bump version to 0.1.8 to fix crates.io publish
- Move changelog entries from Unreleased to 0.1.8

## Test plan
- [ ] CI passes
- [ ] Crate publishes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)