### PR TITLE
Bump version to 0.1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.1.11] - 2026-02-10
+
+### Added
+- **Post-build output verification**: After a node's `build()` returns true, verify that the
+  expected output file exists at its pathbuf in the sandbox. If missing, mark the node as
+  `BuildFailed` and log an error. This catches bugs where a build command writes to the wrong
+  output path.
+
+### Tests
+- `test_buggy_ofile_wrong_output`: Verifies that a buggy OFile writing to "foobar" instead of
+  its pathbuf is correctly detected as `BuildFailed`
+- Updated `test_grootnode_expand`: `GeneratedNode.build()` now creates its output file
+
 ## [0.1.10] - 2026-02-04
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yamake"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2024"
 description="yet another make tool."
 license = "MIT OR Apache-2.0"

--- a/src/make.rs
+++ b/src/make.rs
@@ -360,13 +360,22 @@ impl G {
                     let pathbuf = self.g[node_idx].pathbuf();
                     let pathbuf_str = pathbuf.to_string_lossy().to_string();
                     let output_path = self.sandbox.join(&pathbuf);
-                    let current_digest = compute_file_digest(&output_path);
 
-                    match (&current_digest, previous_digests.get(&pathbuf_str)) {
-                        (Some(current), Some(previous)) if current == previous => {
-                            GNodeStatus::BuildNotChanged
+                    if !output_path.exists() {
+                        error!(
+                            "build succeeded but output file missing: {}",
+                            output_path.display()
+                        );
+                        GNodeStatus::BuildFailed
+                    } else {
+                        let current_digest = compute_file_digest(&output_path);
+
+                        match (&current_digest, previous_digests.get(&pathbuf_str)) {
+                            (Some(current), Some(previous)) if current == previous => {
+                                GNodeStatus::BuildNotChanged
+                            }
+                            _ => GNodeStatus::BuildSuccess,
                         }
-                        _ => GNodeStatus::BuildSuccess,
                     }
                 } else {
                     GNodeStatus::BuildFailed

--- a/tests/test_buggy_ofile_wrong_output.rs
+++ b/tests/test_buggy_ofile_wrong_output.rs
@@ -1,0 +1,95 @@
+//! Test that a buggy OFile writing to the wrong -o path fails to produce the expected output.
+//!
+//! The BuggyOFile passes "foobar" to gcc's -o option instead of the correct pathbuf,
+//! so the compiled object file ends up at the wrong location and the expected output
+//! is never built.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tempdir::TempDir;
+use yamake::c_nodes::CFile;
+use yamake::command::run_command;
+use yamake::model::{G, GNode};
+
+/// A buggy OFile that passes "foobar" to -o instead of the correct pathbuf.
+struct BuggyOFile {
+    name: String,
+}
+
+impl BuggyOFile {
+    fn new(name: &str) -> Self {
+        Self {
+            name: name.to_string(),
+        }
+    }
+}
+
+impl GNode for BuggyOFile {
+    fn build(&self, sandbox: &Path, predecessors: &[&(dyn GNode + Send + Sync)]) -> bool {
+        let inputs: Vec<PathBuf> = predecessors
+            .iter()
+            .filter(|p| p.tag() == "CFile")
+            .map(|p| sandbox.join(p.pathbuf()))
+            .collect();
+
+        let mut cmd = Command::new("gcc");
+        cmd.arg("-c");
+        cmd.arg("-I").arg(sandbox);
+        // BUG: -o uses "foobar" instead of the correct pathbuf
+        cmd.arg("-o").arg(sandbox.join("foobar"));
+        for input in &inputs {
+            cmd.arg(input);
+        }
+
+        run_command(&mut cmd, sandbox, &self.name)
+    }
+
+    fn tag(&self) -> String {
+        "OFile".to_string()
+    }
+
+    fn pathbuf(&self) -> PathBuf {
+        PathBuf::from(&self.name)
+    }
+}
+
+/// This test fails because the BuggyOFile writes the compiled object to "foobar"
+/// instead of "simple/hello.o", so the expected output file is never produced.
+#[test]
+fn test_buggy_ofile_wrong_output() {
+    let srcdir = TempDir::new("yamake_test_srcdir").unwrap();
+    let sandbox = TempDir::new("yamake_test_sandbox").unwrap();
+    let srcdir_path = srcdir.path().to_path_buf();
+    let sandbox_path = sandbox.path().to_path_buf();
+
+    // Create a simple C file that compiles without any includes
+    let c_dir = srcdir_path.join("simple");
+    fs::create_dir_all(&c_dir).unwrap();
+    fs::write(c_dir.join("hello.c"), "int main() { return 0; }\n").unwrap();
+
+    let mut g = G::new(srcdir_path, sandbox_path.clone());
+
+    let hello_c = g.add_root_node(CFile::new("simple/hello.c")).unwrap();
+    let hello_o = g.add_node(BuggyOFile::new("simple/hello.o")).unwrap();
+    g.add_edge(hello_c, hello_o);
+
+    let result = g.make();
+    assert!(
+        !result,
+        "make should fail because the output file is not at the expected path"
+    );
+
+    // The .o file was written to "foobar", not "simple/hello.o"
+    let expected_o = sandbox_path.join("simple/hello.o");
+    assert!(
+        !expected_o.exists(),
+        "Object file should NOT exist at {expected_o:?}"
+    );
+
+    let wrong_o = sandbox_path.join("foobar");
+    assert!(
+        wrong_o.exists(),
+        "Object file was written to the wrong path {wrong_o:?}"
+    );
+}

--- a/tests/test_grootnode_expand.rs
+++ b/tests/test_grootnode_expand.rs
@@ -62,8 +62,12 @@ impl GNode for GeneratedNode {
         PathBuf::from(&self.name)
     }
 
-    fn build(&self, _sandbox: &Path, _predecessors: &[&(dyn GNode + Send + Sync)]) -> bool {
-        true
+    fn build(&self, sandbox: &Path, _predecessors: &[&(dyn GNode + Send + Sync)]) -> bool {
+        let output_path = sandbox.join(&self.name);
+        if let Some(parent) = output_path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        std::fs::write(&output_path, "generated").is_ok()
     }
 }
 


### PR DESCRIPTION
## Summary
- Add post-build output verification: after `build()` returns true, check that the output file exists at the expected pathbuf. If missing, mark the node as `BuildFailed`.
- Add `test_buggy_ofile_wrong_output` test demonstrating detection of a wrong `-o` path
- Update node-life documentation and flowchart with the new output existence check
- Bump version to 0.1.11

## Test plan
- [x] `cargo test` passes (all 20 tests)
- [x] `cargo fmt` clean
- [x] `cargo clippy` clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)