### PR TITLE
Propagate MountedFailed as build failure

### DIFF
--- a/.github/workflows/doc-test.yml
+++ b/.github/workflows/doc-test.yml
@@ -20,7 +20,7 @@ jobs:
           # tar xzf mdbook.tar.gz --directory=./mdbook
           # echo `pwd`/mdbook >> $GITHUB_PATH
           # install
-          cargo install mdbook mdbook-mermaid mdbook-alerts mdbook-emojicodes mdbook-toc mdbook-pikchr
+          cargo install mdbook mdbook-mermaid mdbook-mermaid-animate mdbook-alerts mdbook-emojicodes mdbook-toc mdbook-pikchr
           mdbook-mermaid install doc
       - name: Build Book
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1666,7 +1666,7 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "yamake"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "argh",
  "chrono",

--- a/tests/test_grootnode_expand.rs
+++ b/tests/test_grootnode_expand.rs
@@ -94,11 +94,17 @@ impl GRootNode for ExpandingRootNode {
 
         let nodes: Vec<Box<dyn GNode + Send + Sync>> = vec![Box::new(node1), Box::new(node2)];
 
-        // Create an edge from this root to the first generated node
-        let edges: Vec<Edge> = vec![Edge {
-            nfrom: Box::new(ExpandingRootNode::new(&self.name)),
-            nto: Box::new(GeneratedNode::new("generated/node1.txt")),
-        }];
+        // Create edges from this root to both generated nodes
+        let edges: Vec<Edge> = vec![
+            Edge {
+                nfrom: Box::new(ExpandingRootNode::new(&self.name)),
+                nto: Box::new(GeneratedNode::new("generated/node1.txt")),
+            },
+            Edge {
+                nfrom: Box::new(ExpandingRootNode::new(&self.name)),
+                nto: Box::new(GeneratedNode::new("generated/node2.txt")),
+            },
+        ];
 
         Ok((nodes, edges))
     }

--- a/tests/test_mount_missing_source.rs
+++ b/tests/test_mount_missing_source.rs
@@ -1,0 +1,46 @@
+//! Test that a missing source file causes the build to fail.
+//!
+//! When a CFile references a source that does not exist in the source directory,
+//! mount should fail and make() should return false.
+
+use tempdir::TempDir;
+use yamake::c_nodes::{CFile, OFile};
+use yamake::model::{G, GNodeStatus};
+
+#[test]
+fn test_mount_missing_source() {
+    let srcdir = TempDir::new("yamake_test_srcdir").unwrap();
+    let sandbox = TempDir::new("yamake_test_sandbox").unwrap();
+    let srcdir_path = srcdir.path().to_path_buf();
+    let sandbox_path = sandbox.path().to_path_buf();
+
+    // Do NOT create any source file — "missing/hello.c" does not exist
+
+    let mut g = G::new(srcdir_path, sandbox_path.clone());
+
+    let hello_c = g.add_root_node(CFile::new("missing/hello.c")).unwrap();
+    let hello_o = g
+        .add_node(OFile::new("missing/hello.o", vec![], vec![]))
+        .unwrap();
+    g.add_edge(hello_c, hello_o);
+
+    let result = g.make();
+    assert!(
+        !result,
+        "make should fail when a source file cannot be mounted"
+    );
+
+    let c_status = g.nodes_status.get(&hello_c);
+    assert_eq!(
+        c_status,
+        Some(&GNodeStatus::MountedFailed),
+        "hello.c should be MountedFailed, got {c_status:?}"
+    );
+
+    let o_status = g.nodes_status.get(&hello_o);
+    assert_eq!(
+        o_status,
+        Some(&GNodeStatus::AncestorFailed),
+        "hello.o should be AncestorFailed, got {o_status:?}"
+    );
+}


### PR DESCRIPTION
## Summary
- `make()` now returns `false` when any node has `MountedFailed` or `AncestorFailed` status (previously only checked `BuildFailed`)
- `build_nodes()` now checks `ScanIncomplete` nodes for failed predecessors, propagating `AncestorFailed` when a predecessor is `MountedFailed`
- New test `test_mount_missing_source`: verifies that a missing source file causes `MountedFailed` on the root node, `AncestorFailed` on dependents, and `make()` returns `false`
- Fixed `test_grootnode_expand`: both generated nodes now have edges from the root

## Test plan
- [x] `cargo test` — all 22 tests pass
- [x] `cargo fmt` — clean
- [x] `cargo clippy` — clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)